### PR TITLE
Bug Fix

### DIFF
--- a/resources/lib/games_archive.py
+++ b/resources/lib/games_archive.py
@@ -151,7 +151,7 @@ def getGameLinks(url):
             awayTeam = game[3]
             linkList = [title, [homeTeam, awayTeam]]
            
-            #Quality settings            
+            #Quality settings     
             if QUALITY == 4 or 'bestquality' in url:
                 if int(year) >= 2014:
                     quality = '_5000'
@@ -160,8 +160,9 @@ def getGameLinks(url):
             elif '5000K' in url:
                 quality = '_5000'
             elif QUALITY == 3 or '4500K' in url:
-                quality = '_4500'
-                if int(year) >= 2012:
+                if int(year) >= 2014:
+                    quality = '_5000'
+                elif int(year) >= 2012:
                     quality = '_4500'
                 else:
                     quality = '_3000'


### PR DESCRIPTION
If video quality was set to 5000kpbs and the user attempted to play a archive
video from this year it wouldn't play because the url was getting 4500 set.
I corrected the if statement to select 5000 if stream is from 2014 and on.
