### PR TITLE
Fix for cutoff dates in list

### DIFF
--- a/resources/lib/games_live.py
+++ b/resources/lib/games_live.py
@@ -163,7 +163,7 @@ def getLiveGames(live):
             if awayTeam in teams and homeTeam in teams:
                 title = teams[awayTeam][TEAMNAME] + " " + awayTeamScore + LOCAL_STRING(versus) + " " + teams[homeTeam][TEAMNAME] + " " + homeTeamScore 
             else:
-                title = awayTeam + " " + awayTeamScore + " " + LOCAL_STRING(versus) + " " + homeTeam + " " + homeTeamScore
+                title = awayTeam + " " + awayTeamScore + LOCAL_STRING(versus) + " " + homeTeam + " " + homeTeamScore
         
         #Add to the list of live games
         gameList.append([gid, season, Type, Id, gameStarted, title, homeTeam, awayTeam, localDate, sortByDate])

--- a/resources/lib/games_live.py
+++ b/resources/lib/games_live.py
@@ -87,8 +87,8 @@ def getLiveGames(live):
            
             try:                
                 ht = homeTeam
-                at = awayTeam      
-                json_scoreboard = getScoreBoard(date[0:10])                                       
+                at = awayTeam
+                json_scoreboard = getScoreBoard(date[0:10])
                 #Display Date
                
                 for sb_game in json_scoreboard['games']:                                
@@ -117,8 +117,8 @@ def getLiveGames(live):
                     if ht == str(sb_game['hta']) and at == str(sb_game['ata']):
                         #print "WE FOUND A MATCH"
                         homeTeamScore = '[COLOR=FF00B7EB]' + str(sb_game['hts']) +'[/COLOR]'
-                        awayTeamScore = '[COLOR=FF00B7EB]' + str(sb_game['ats']) +'[/COLOR]'
-                        gameTime = str(sb_game['bs'])                    
+                        awayTeamScore = '[COLOR=FF00B7EB]' + str(sb_game['ats']) +'[/COLOR] '
+                        gameTime = str(sb_game['bs'])
             except:
                 pass
 
@@ -148,24 +148,25 @@ def getLiveGames(live):
             if gameTime == '':
                 gameTime = "Live"
             #Displayed titlestring
-            if awayTeam in teams and homeTeam in teams:                
-                title = gameTime + " - " + teams[awayTeam][TEAMNAME] + " " + awayTeamScore + " " + LOCAL_STRING(versus) + " " + teams[homeTeam][TEAMNAME] + " " + homeTeamScore
+            if awayTeam in teams and homeTeam in teams:
+                title = gameTime + " - " + teams[awayTeam][TEAMNAME] + " " + awayTeamScore + LOCAL_STRING(versus) + " " + teams[homeTeam][TEAMNAME] + " " + homeTeamScore
             else:
-                title = gameTime + " - " + awayTeam + " " + awayTeamScore + " " + LOCAL_STRING(versus) + " " + homeTeam + " " + homeTeamScore
+                title = gameTime + " - " + awayTeam + " " + awayTeamScore + LOCAL_STRING(versus) + " " + homeTeam + " " + homeTeamScore
         else:
             #Convert the time to the local timezone
             date = datetime.fromtimestamp(time.mktime(startTime))
-            date = date.replace(tzinfo=tz.gettz('America/New_York'))            
-            datelocal = date.astimezone(tz.tzlocal()).strftime(xbmc.getRegion('dateshort')+' '+xbmc.getRegion('time').replace('%H%H','%H').replace(':%S',''))           
+            date = date.replace(tzinfo=tz.gettz('America/New_York'))
+            localDate = date.astimezone(tz.tzlocal()).strftime(xbmc.getRegion('dateshort'))
+	    sortByDate = date.astimezone(tz.tzlocal()).strftime('%Y-%m-%d')
 
             #Displayed titlestring
             if awayTeam in teams and homeTeam in teams:
-                title = datelocal + ': ' + teams[awayTeam][TEAMNAME] + " " + awayTeamScore + " " + LOCAL_STRING(versus) + " " + teams[homeTeam][TEAMNAME] + " " + homeTeamScore                
+                title = teams[awayTeam][TEAMNAME] + " " + awayTeamScore + LOCAL_STRING(versus) + " " + teams[homeTeam][TEAMNAME] + " " + homeTeamScore 
             else:
-                title = datelocal + ': ' + awayTeam + " " + awayTeamScore + " " + LOCAL_STRING(versus) + " " + homeTeam + " " + homeTeamScore
+                title = awayTeam + " " + awayTeamScore + " " + LOCAL_STRING(versus) + " " + homeTeam + " " + homeTeamScore
         
         #Add to the list of live games
-        gameList.append([gid, season, Type, Id, gameStarted, title, homeTeam, awayTeam])
+        gameList.append([gid, season, Type, Id, gameStarted, title, homeTeam, awayTeam, localDate, sortByDate])
     
     
     #Save the gameList

--- a/resources/lib/userinterface.py
+++ b/resources/lib/userinterface.py
@@ -98,9 +98,8 @@ def LIVE(url):
             else: #Go to the stream selection screen
                 addDir(game[5],url + "/" + game[0],3,iconPath,True)
         else:
-            teams = game[5][21:]
-            time = game[5][11:19]
-            time = time.lstrip("0")            
+            teams = game[5]
+            time = game[10]
             addDir(teams + " at " + time,url,1,iconPath,True)    
 
 def LIVEQUALITY(url):    

--- a/resources/lib/userinterface.py
+++ b/resources/lib/userinterface.py
@@ -277,14 +277,16 @@ def LATESTGAMES(url):
         if USETHUMBNAILS == 'true':
             iconPath = os.path.join(ADDON_PATH_PROFILE, "images/" + THUMBFORMAT + "_" + BACKGROUND + "/"+ game[7] + "vs" + game[6] + ".png")
         
+        #If date changed, echo the new date
+	if date <> game[9]:
+            date = game[9]
+            addLink('[COLOR=FFFFFFFF][B][I]' + game[8] + '[/I][/B][/COLOR]','','','')
+        
         #Add Game
-        if date <> game[5][0:10]:
-            date = game[5][0:10]
-            addLink('[COLOR=FFFFFFFF][B][I]' + date + '[/I][/B][/COLOR]','','','')
         if game[4]:
-            addDir(game[5][21:],url + "/" + game[0],14,iconPath,True)
+            addDir(game[5],url + "/" + game[0],14,iconPath,True)
         else:
-            addDir(game[5][21:],url,11,iconPath,True)
+            addDir(game[5],url,11,iconPath,True)
 
 
 def LATESTGTYPE(url):


### PR DESCRIPTION
A fix for my problem in #27.

The original code stored the game's date and time at the start of the title and then cut the string up. That won't work when the date and time can be different lengths.

Now ``title`` just stores the title, and I added two other fields to ``gameList``:

* ``localDate``  the localized date in user defined format for this game and converted to the user's timezone.
* ``localDateTime`` the localized date and time in the user defined format, and converted to local timezone.
* ``sortByDate`` the date in YYYY-MM-DD format. Used internally only to know if two dates are different. Perhaps not 100% needed but feels safer.

Also fixed another minor annoyance I had, there was an extra space when you didn't show scores. Changed so ``awayTeamScore`` will have a space after it and removed them from ``title``.

Cleaned up ``title`` generation.

Removed some excessive spaces at the end of a few lines I saw.